### PR TITLE
Error out when self-ref set operation in recursive term

### DIFF
--- a/src/test/regress/expected/with.out
+++ b/src/test/regress/expected/with.out
@@ -514,6 +514,11 @@ WITH RECURSIVE x(n) AS (SELECT 1 EXCEPT ALL SELECT n+1 FROM x)
 ERROR:  recursive query "x" does not have the form non-recursive-term UNION ALL recursive-term
 LINE 1: WITH RECURSIVE x(n) AS (SELECT 1 EXCEPT ALL SELECT n+1 FROM ...
                        ^
+-- Set operations within the recursive term with a self-reference
+WITH RECURSIVE x(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM (SELECT 1 UNION x) foo)
+	SELECT * FROM x;
+ERROR:  Self reference of "x" within recursive term not supported
+
 -- no non-recursive term
 WITH RECURSIVE x(n) AS (SELECT n FROM x)
 	SELECT * FROM x;

--- a/src/test/regress/sql/with.sql
+++ b/src/test/regress/sql/with.sql
@@ -276,6 +276,10 @@ WITH RECURSIVE x(n) AS (SELECT 1 EXCEPT SELECT n+1 FROM x)
 WITH RECURSIVE x(n) AS (SELECT 1 EXCEPT ALL SELECT n+1 FROM x)
 	SELECT * FROM x;
 
+-- Set operations within the recursive term with a self-reference
+WITH RECURSIVE x(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM (SELECT 1 UNION x) foo)
+	SELECT * FROM x;
+
 -- no non-recursive term
 WITH RECURSIVE x(n) AS (SELECT n FROM x)
 	SELECT * FROM x;


### PR DESCRIPTION
This commit ensures that if there is ever a self reference to a
recursive cte within a set operation in the recursive term an error will
be produced

For example

WITH RECURSIVE foo(i) {
	SELECT 1
	UNION ALL
	SELECT i+1 FROM (SELECT * FROM foo UNION SELECT 0) bar
	)
SELECT * FROM foo LIMIT 5;

Will produce an error, while

WITH RECURSIVE foo(i) {
	SELECT 1
	UNION ALL
	SELECT i+1 FROM (SELECT * FROM bar UNION SELECT 0) car, foo
	where foo.i = bar.a
	)
SELECT * FROM foo LIMIT 5;

Will not because the set operation does not have a self reference to its
cte.